### PR TITLE
Fix warning upon SAML login

### DIFF
--- a/src/EventSubscriber/UserSyncEventSubscriber.php
+++ b/src/EventSubscriber/UserSyncEventSubscriber.php
@@ -59,7 +59,7 @@ class UserSyncEventSubscriber implements EventSubscriberInterface {
       $attributes = $event->getAttributes();
       foreach ($user_mappings as $field_name => $mapping) {
         $method = "set" . ucfirst($field_name) . 'Attribute';
-        if (!empty($mapping['attribute'])) {
+        if (!empty($mapping['attribute']) && isset($attributes[$mapping['attribute']])) {
           if ($value = $attributes[$mapping['attribute']]) {
             if (method_exists($this, $method)) {
               $this->$method($event, $value[0]);


### PR DESCRIPTION
The root cause is that not every user has the same set of attributes, we should not choke on that.